### PR TITLE
Support more complex merge var content

### DIFF
--- a/src/Mandrill.net/Model/Messages/MandrillMergeVarContent.cs
+++ b/src/Mandrill.net/Model/Messages/MandrillMergeVarContent.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Mandrill.Model
 {
@@ -14,9 +15,9 @@ namespace Mandrill.Model
             ValueAsString = value;
         }
 
-        public MandrillMergeVarContent(List<Dictionary<string, object>> value)
+        public MandrillMergeVarContent(IEnumerable<IDictionary<string, object>> value)
         {
-            ValueAsArray = value;
+            ValueAsArray = value.Select(x => new Dictionary<string, object>(x)).ToList();
         }
 
         public string ValueAsString { get; set; }
@@ -43,9 +44,19 @@ namespace Mandrill.Model
             return new MandrillMergeVarContent(value);
         }
 
+        public static implicit operator MandrillMergeVarContent(List<IDictionary<string, object>> value)
+        {
+            return new MandrillMergeVarContent(value);
+        }
+
         public static implicit operator MandrillMergeVarContent(List<Dictionary<string, object>> value)
         {
             return new MandrillMergeVarContent(value);
+        }
+
+        public static implicit operator MandrillMergeVarContent(List<Dictionary<string, string>> value)
+        {
+            return new MandrillMergeVarContent(value.Select(x => x.ToDictionary(y => y.Key, y => (object) y.Value)));
         }
 
         public override bool Equals(object obj)

--- a/src/Mandrill.net/Model/Messages/MandrillMergeVarContent.cs
+++ b/src/Mandrill.net/Model/Messages/MandrillMergeVarContent.cs
@@ -14,14 +14,14 @@ namespace Mandrill.Model
             ValueAsString = value;
         }
 
-        public MandrillMergeVarContent(List<Dictionary<string, string>> value)
+        public MandrillMergeVarContent(List<Dictionary<string, object>> value)
         {
             ValueAsArray = value;
         }
 
         public string ValueAsString { get; set; }
 
-        public List<Dictionary<string, string>> ValueAsArray { get; set; }
+        public List<Dictionary<string, object>> ValueAsArray { get; set; }
 
         public bool Equals(MandrillMergeVarContent other)
         {
@@ -43,7 +43,7 @@ namespace Mandrill.Model
             return new MandrillMergeVarContent(value);
         }
 
-        public static implicit operator MandrillMergeVarContent(List<Dictionary<string, string>> value)
+        public static implicit operator MandrillMergeVarContent(List<Dictionary<string, object>> value)
         {
             return new MandrillMergeVarContent(value);
         }

--- a/src/Mandrill.net/Model/Messages/MandrillMessage.cs
+++ b/src/Mandrill.net/Model/Messages/MandrillMessage.cs
@@ -189,10 +189,17 @@ namespace Mandrill.Model
             GlobalMergeVars.Add(new MandrillMergeVar {Name = name, Content = new MandrillMergeVarContent(content)});
         }
 
+        [Obsolete("Use overload with IEnumerable<Dictionary<string, object>> type")]
         public void AddGlobalMergeVars(string name, IEnumerable<Dictionary<string, string>> content)
         {
-            GlobalMergeVars.Add(new MandrillMergeVar { Name = name, Content = new MandrillMergeVarContent(content.ToList()) });
+            AddGlobalMergeVars(name, content.Select(v => v.ToDictionary(x => x.Key, x => (object) x.Value)));
         }
+
+        public void AddGlobalMergeVars(string name, IEnumerable<Dictionary<string, object>> content)
+        {
+            GlobalMergeVars.Add(new MandrillMergeVar {Name = name, Content = new MandrillMergeVarContent(content.ToList())});
+        }
+
 
         public void AddRcptMergeVars(string rcptEmail, string name, string content)
         {
@@ -204,14 +211,20 @@ namespace Mandrill.Model
             mergeVar.Vars.Add(new MandrillMergeVar {Name = name, Content = new MandrillMergeVarContent(content)});
         }
 
+        [Obsolete("Use overload with IEnumerable<Dictionary<string, object>> type")]
         public void AddRcptMergeVars(string rcptEmail, string name, IEnumerable<Dictionary<string, string>> content)
+        {
+            AddRcptMergeVars(rcptEmail, name, content.Select(v => v.ToDictionary(x => x.Key, x => (object) x.Value)));
+        }
+
+        public void AddRcptMergeVars(string rcptEmail, string name, IEnumerable<Dictionary<string, object>> content)
         {
             var mergeVar = MergeVars.FirstOrDefault(x => x.Rcpt == rcptEmail);
             if (mergeVar == null)
             {
-                MergeVars.Add(mergeVar = new MandrillRcptMergeVar { Rcpt = rcptEmail });
+                MergeVars.Add(mergeVar = new MandrillRcptMergeVar {Rcpt = rcptEmail});
             }
-            mergeVar.Vars.Add(new MandrillMergeVar { Name = name, Content = new MandrillMergeVarContent(content.ToList()) });
+            mergeVar.Vars.Add(new MandrillMergeVar {Name = name, Content = new MandrillMergeVarContent(content.ToList())});
         }
 
 

--- a/src/Mandrill.net/Model/Messages/MandrillMessage.cs
+++ b/src/Mandrill.net/Model/Messages/MandrillMessage.cs
@@ -192,12 +192,26 @@ namespace Mandrill.Model
         [Obsolete("Use overload with IEnumerable<Dictionary<string, object>> type")]
         public void AddGlobalMergeVars(string name, IEnumerable<Dictionary<string, string>> content)
         {
-            AddGlobalMergeVars(name, content.Select(v => v.ToDictionary(x => x.Key, x => (object) x.Value)));
+            AddGlobalMergeVars(name, content.Select(dictionary => 
+                dictionary.ToDictionary(pair => pair.Key, pair => (object) pair.Value)));
         }
 
-        public void AddGlobalMergeVars(string name, IEnumerable<Dictionary<string, object>> content)
+        public void AddGlobalMergeVars(string name, IEnumerable<IDictionary<string, object>> content)
         {
-            GlobalMergeVars.Add(new MandrillMergeVar {Name = name, Content = new MandrillMergeVarContent(content.ToList())});
+            GlobalMergeVars.Add(new MandrillMergeVar
+            {
+                Name = name,
+                Content = new MandrillMergeVarContent(content)
+            });
+        }
+
+        public void AddGlobalMergeVars(string name, params IDictionary<string, object>[] content)
+        {
+            GlobalMergeVars.Add(new MandrillMergeVar
+            {
+                Name = name,
+                Content = new MandrillMergeVarContent(content)
+            });
         }
 
 
@@ -208,25 +222,37 @@ namespace Mandrill.Model
             {
                 MergeVars.Add(mergeVar = new MandrillRcptMergeVar {Rcpt = rcptEmail});
             }
-            mergeVar.Vars.Add(new MandrillMergeVar {Name = name, Content = new MandrillMergeVarContent(content)});
+            mergeVar.Vars.Add(new MandrillMergeVar
+            {
+                Name = name,
+                Content = new MandrillMergeVarContent(content)
+            });
         }
 
-        [Obsolete("Use overload with IEnumerable<Dictionary<string, object>> type")]
+        [Obsolete("Use overload with IEnumerable<IDictionary<string, object>> type")]
         public void AddRcptMergeVars(string rcptEmail, string name, IEnumerable<Dictionary<string, string>> content)
         {
             AddRcptMergeVars(rcptEmail, name, content.Select(v => v.ToDictionary(x => x.Key, x => (object) x.Value)));
         }
 
-        public void AddRcptMergeVars(string rcptEmail, string name, IEnumerable<Dictionary<string, object>> content)
+        public void AddRcptMergeVars(string rcptEmail, string name, IEnumerable<IDictionary<string, object>> content)
         {
             var mergeVar = MergeVars.FirstOrDefault(x => x.Rcpt == rcptEmail);
             if (mergeVar == null)
             {
                 MergeVars.Add(mergeVar = new MandrillRcptMergeVar {Rcpt = rcptEmail});
             }
-            mergeVar.Vars.Add(new MandrillMergeVar {Name = name, Content = new MandrillMergeVarContent(content.ToList())});
+            mergeVar.Vars.Add(new MandrillMergeVar
+            {
+                Name = name,
+                Content = new MandrillMergeVarContent(content)
+            });
         }
 
+        public void AddRcptMergeVars(string rcptEmail, string name, params IDictionary<string, object>[] content)
+        {
+            AddRcptMergeVars(rcptEmail, name, content.ToList());
+        }
 
         public void AddMetadata(string key, string value)
         {

--- a/src/Mandrill.net/Serialization/MandrillMergeVarContentConverter.cs
+++ b/src/Mandrill.net/Serialization/MandrillMergeVarContentConverter.cs
@@ -47,7 +47,7 @@ namespace Mandrill.Serialization
             if (reader.TokenType == JsonToken.StartArray)
             {
                 var jArray = JArray.Load(reader);
-                return new MandrillMergeVarContent(jArray.ToObject<List<Dictionary<string, string>>>(serializer));
+                return new MandrillMergeVarContent(jArray.ToObject<List<Dictionary<string, object>>>(serializer));
             }
 
             throw new JsonSerializationException("Unexpected tokenType " + reader.TokenType);

--- a/tests/Tests/Messages.cs
+++ b/tests/Tests/Messages.cs
@@ -454,7 +454,7 @@ namespace Tests
                 {
                     FromEmail = "mandrill.net@example.com",
                     Subject = "test",
-                    Tags = new List<string>() { "test-send-template", "mandrill-net" },
+                    Tags = new List<string>() { "test-send-template", "mandrill-net", "handlebars" },
                     MergeLanguage = MandrillMessageMergeLanguage.Handlebars,
                     To = new List<MandrillMailAddress>()
                     {
@@ -466,48 +466,48 @@ namespace Tests
 
                 var data1 = new[]
                 {
-                    new Dictionary<string, string>
+                    new Dictionary<string, object>
                     {
                         {"sku", "APL43"},
                         {"name", "apples"},
                         {"description", "Granny Smith Apples"},
-                        {"price", "$0.20"},
-                        {"qty", "8"},
-                        {"ordPrice", "$1.60"},
+                        {"price", 0.20},
+                        {"qty", 8},
+                        {"ordPrice", 1.60},
 
                     },
-                    new Dictionary<string, string>
+                    new Dictionary<string, object>
                     {
                         {"sku", "ORA44"},
                         {"name", "Oranges"},
                         {"description", "Blood Oranges"},
-                        {"price", "$0.30"},
-                        {"qty", "3"},
-                        {"ordPrice", "$0.93"},
+                        {"price", 0.30},
+                        {"qty", 3},
+                        {"ordPrice", 0.93},
 
                     }
                 };
 
                 var data2 = new[]
                 {
-                    new Dictionary<string, string>
+                    new Dictionary<string, object>
                     {
                         {"sku", "APL54"},
                         {"name", "apples"},
                         {"description", "Red Delicious Apples"},
-                        {"price", "$0.22"},
-                        {"qty", "9"},
-                        {"ordPrice", "$1.98"},
+                        {"price", 0.22},
+                        {"qty", 9},
+                        {"ordPrice", 1.98},
 
                     },
-                    new Dictionary<string, string>
+                    new Dictionary<string, object>
                     {
                         {"sku", "ORA53"},
                         {"name", "Oranges"},
                         {"description", "Sunkist Oranges"},
-                        {"price", "$0.20"},
-                        {"qty", "1"},
-                        {"ordPrice", "$0.20"},
+                        {"price", 0.20},
+                        {"qty", 1},
+                        {"ordPrice", 0.20},
 
                     }
                 };

--- a/tests/Tests/SerializationTests.cs
+++ b/tests/Tests/SerializationTests.cs
@@ -51,7 +51,7 @@ namespace Tests
         {
             var message = new MandrillMessage();
 
-            var data = new[]
+            var data = new IDictionary<string, object>[]
             {
                 new Dictionary<string, object>
                 {

--- a/tests/Tests/SerializationTests.cs
+++ b/tests/Tests/SerializationTests.cs
@@ -53,15 +53,15 @@ namespace Tests
 
             var data = new[]
             {
-                new Dictionary<string, string>
+                new Dictionary<string, object>
                 {
                     {"sku", "apples"},
-                    {"unit_price", "$0.20"},
+                    {"unit_price", 0.20},
                 },
-                new Dictionary<string, string>
+                new Dictionary<string, object>
                 {
                     {"sku", "oranges"},
-                    {"unit_price", "$0.40"},
+                    {"unit_price", 0.40},
                 }
             };
 
@@ -75,12 +75,12 @@ namespace Tests
             Console.WriteLine(json.ToString());
             json["global_merge_vars"].Should().NotBeEmpty();
             var result = json["global_merge_vars"].First["content"]
-                .ToObject<List<Dictionary<string, string>>>(MandrillSerializer.Instance);
+                .ToObject<List<Dictionary<string, object>>>(MandrillSerializer.Instance);
 
             result[0]["sku"].Should().Be("apples");
-            result[0]["unit_price"].Should().Be("$0.20");
+            result[0]["unit_price"].Should().Be(0.20);
             result[1]["sku"].Should().Be("oranges");
-            result[1]["unit_price"].Should().Be("$0.40");
+            result[1]["unit_price"].Should().Be(0.40);
         }
 
         [Test]


### PR DESCRIPTION
Since mandrill's handlebar templates can take essentially any valid object graph, move from `Dictionary<string,string>` type to `IDictionary<string,object>` type. Added more convenience overrides to MandrillMessage and integration tests