### PR TITLE
Adding two more properties to the models used for webhooks.

### DIFF
--- a/src/Mandrill.net/Model/WebHook/MandrillMessageEventInfo.cs
+++ b/src/Mandrill.net/Model/WebHook/MandrillMessageEventInfo.cs
@@ -66,6 +66,6 @@ namespace Mandrill.Model
         public string BounceDescription { get; set; }
 
         [JsonProperty("bgtools_code")]
-        public int BgToolsCode { get; set; }
+        public int? BgToolsCode { get; set; }
     }
 }

--- a/src/Mandrill.net/Model/WebHook/MandrillMessageEventInfo.cs
+++ b/src/Mandrill.net/Model/WebHook/MandrillMessageEventInfo.cs
@@ -64,5 +64,8 @@ namespace Mandrill.Model
         public string Diag { get; set; }
 
         public string BounceDescription { get; set; }
+
+        [JsonProperty("bgtools_code")]
+        public int BgToolsCode { get; set; }
     }
 }

--- a/src/Mandrill.net/Model/WebHook/MandrillSyncEvent.cs
+++ b/src/Mandrill.net/Model/WebHook/MandrillSyncEvent.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Mandrill.Serialization;
 using Newtonsoft.Json;
@@ -7,6 +8,8 @@ namespace Mandrill.Model
 {
     public class MandrillSyncEvent
     {
+        public DateTime Ts { get; set; }
+
         public MandrillSyncType Type { get; set; }
         
         public MandrillSyncAction Action { get; set; }


### PR DESCRIPTION
Ts is noted within the documentation.

bgtools_code is not.  Here is a snippet with that field being populated though (from the mandrill site when testing a webhook):

```json
    {
      "event": "hard_bounce",
      "msg": {
        "ts": 1365109999,
        "subject": "This an example webhook message",
        "email": "example.webhook@mandrillapp.com",
        "sender": "example.sender@mandrillapp.com",
        "tags": [ "webhook-example" ],
        "state": "bounced",
        "metadata": { "user_id": 111 },
        "_id": "exampleaaaaaaaaaaaaaaaaaaaaaaaaa2",
        "_version": "exampleaaaaaaaaaaaaaaa",
        "bounce_description": "bad_mailbox",
        "bgtools_code": 10,
        "diag": "smtp;550 5.1.1 The email account that you tried to reach does not exist. Please try double-checking the recipient's email address for typos or unnecessary spaces."
      }
```