### PR TITLE
Nullable Ts field on MandrillMessageEventInfo

### DIFF
--- a/src/Mandrill.net/Model/WebHook/MandrillMessageEventInfo.cs
+++ b/src/Mandrill.net/Model/WebHook/MandrillMessageEventInfo.cs
@@ -11,7 +11,7 @@ namespace Mandrill.Model
         private List<MandrillOpensDetail> _opens;
         private List<MandrillSmtpEvent> _smtpEvents;
         private List<string> _tags;
-        public DateTime Ts { get; set; }
+        public DateTime? Ts { get; set; }
 
         [JsonProperty("_id")]
         public string Id { get; set; }


### PR DESCRIPTION
Allowing for the Ts property of the EventInfo model to be null. Reason for this is that during open events, this field can come from Mandrill as null.

Example message I got for an open event in my app:
``` json
 {
    "event": "open",
    "ts": 1455569318,
    "user_agent": "Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit\/600.8.9 (KHTML, like Gecko)",
    "user_agent_parsed": {
      "type": "Email Client",
      "ua_family": "Apple Mail",
      "ua_name": "Apple Mail",
      "ua_version": null,
      "ua_url": "http:\/\/en.wikipedia.org\/wiki\/Apple_mail",
      "ua_company": "Apple Inc.",
      "ua_company_url": "http:\/\/www.apple.com\/",
      "ua_icon": "http:\/\/cdn.mandrill.com\/img\/email-client-icons\/apple-mail.png",
      "os_family": "OS X",
      "os_name": "OS X",
      "os_url": "http:\/\/www.apple.com\/osx\/",
      "os_company": "Apple Computer, Inc.",
      "os_company_url": "http:\/\/www.apple.com\/",
      "os_icon": "http:\/\/cdn.mandrill.com\/img\/email-client-icons\/macosx.png",
      "mobile": false
    },
    "ip": "71.xx.xx.xxx",
    "location": {
      ...
    },
    "_id": "removed",
    "msg": {
      "tags": [ ],
      "sender": null,
      "template": null
    }
  }
```