### PR TITLE
Flushing out sender details based on sync event encountered

### DIFF
--- a/src/Mandrill.net/Model/WebHook/MandrillSyncEventReject.cs
+++ b/src/Mandrill.net/Model/WebHook/MandrillSyncEventReject.cs
@@ -23,7 +23,7 @@ namespace Mandrill.Model
 
         public string Reason { get; set; }
 
-        public string Sender { get; set; }
+        public MandrillSyncEventSender Sender { get; set; }
 
         public string Subaccount { get; set; }
     }

--- a/src/Mandrill.net/Model/WebHook/MandrillSyncEventSender.cs
+++ b/src/Mandrill.net/Model/WebHook/MandrillSyncEventSender.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Mandrill.Model
+{
+    public class MandrillSyncEventSender
+    {
+        public int? Sent { get; set; }
+
+        public int? HardBounces { get; set; }
+
+        public int? SoftBounces { get; set; }
+
+        public int? Rejects { get; set; }
+
+        public int? Complaints { get; set; }
+
+        public int? Unsubs { get; set; }
+
+        public int? Opens { get; set; }
+        
+        public int? Clicks { get; set; }
+
+        public int? UniqueOpens { get; set; }
+
+        public int? UniqueClicks { get; set; }
+
+        public int? Reputation { get; set; }
+
+        public string Address { get; set; }
+
+        [JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/src/Mandrill.net/csproj/Mandrill.csproj
+++ b/src/Mandrill.net/csproj/Mandrill.csproj
@@ -115,6 +115,7 @@
     <Compile Include="..\Model\WebHook\MandrillSyncEvent.cs" />
     <Compile Include="..\Model\WebHook\MandrillSyncEventEntry.cs" />
     <Compile Include="..\Model\WebHook\MandrillSyncEventReject.cs" />
+	<Compile Include="..\Model\WebHook\MandrillSyncEventSender.cs" />
     <Compile Include="..\Model\WebHook\MandrillSyncType.cs" />
     <Compile Include="..\Model\Messages\MandrillMessageInfo.cs" />
     <Compile Include="..\Model\Messages\MandrillMessageInfoRequest.cs" />


### PR DESCRIPTION
The documentation at [https://mandrill.zendesk.com/hc/en-us/articles/205583297-Sync-Event-Webhook-format] suggests that the sender would be a string representing the sender.  That is not the case though.  It's actually a collection of attributes about the sender.

Here's an example message showing the details flushed out:
`mandrill_events=[
{
	"type":"blacklist",
	"action":"add",
	"reject":
	{
		"reason":"spam",
		"detail":null,
		"last_event_at":"2016-03-01 13:10:08",
		"email":"some@email.net",
		"created_at":"2016-03-01 13:10:08",
		"expires_at":"2017-03-01 13:10:08",
		"expired":false,
		"subaccount":null,
		"sender":
		{
			"sent":44,
			"hard_bounces":0,
			"soft_bounces":0,
			"rejects":0,
			"complaints":0,
			"unsubs":0,
			"opens":6,
			"clicks":0,
			"unique_opens":4,
			"unique_clicks":0,
			"reputation":0,
			"address":"from@someemail.com",
			"created_at":"2016-02-25 18:41:07.06801"
		}
	},
	"ts":1456837808
}]`