### PR TITLE
Add IsoDateTimeConverter to MandrillSenderDomain.VerifiedAt

### DIFF
--- a/src/Mandrill.net/Model/Senders/MandrillSenderDomain.cs
+++ b/src/Mandrill.net/Model/Senders/MandrillSenderDomain.cs
@@ -14,6 +14,7 @@ namespace Mandrill.Model
         public DateTime LastTestedAt { get; set; }
         public MandrillSenderValidDetails SPF { get; set; }
         public MandrillSenderValidDetails DKIM { get; set; }
+        [JsonConverter(typeof(IsoDateTimeConverter))]
         public DateTime VerifiedAt { get; set; }
         public bool ValidSigning { get; set; }
         public MandrillSenderVerifyDomain Verified { get; set; }


### PR DESCRIPTION
[`MandrillSenderDomain.VerifiedAt`](https://github.com/feinoujc/Mandrill.net/tree/da6ecba82b44daf460af92477a51cbed7521cfa8/src/Mandrill.net/Model/Senders/MandrillSenderDomain.cs#L17) field didn't have a `JsonConverter` attribute with an argument of type `IsoDateTimeConverter`. This fixes the [`Domains.Can_list_sender_domains`](https://github.com/feinoujc/Mandrill.net/tree/da6ecba82b44daf460af92477a51cbed7521cfa8/tests/Senders.cs#L39) test.