### PR TITLE
Include CC recipients on inbound event message

### DIFF
--- a/src/Mandrill.net/Model/WebHook/MandrillInboundMessageInfo.cs
+++ b/src/Mandrill.net/Model/WebHook/MandrillInboundMessageInfo.cs
@@ -38,5 +38,7 @@ namespace Mandrill.Model
         public bool TextFlowed { get; set; }
 
         public List<List<string>> To { get; set; } = new List<List<string>>();
+        
+        public List<List<string>> CC { get; set; } = new List<List<string>>();
     }
 }


### PR DESCRIPTION
The MandrillInboundMessageInfo class is missing the CC property which while not shown in the Mandrill sample payload, is included in the documentation and populated correctly in the webhook payload that is sent