### PR TITLE
Added missing FromName and CC properties to MandrillInboundMessageInfo

### DIFF
--- a/src/Mandrill.net/Model/WebHook/MandrillInboundMessageInfo.cs
+++ b/src/Mandrill.net/Model/WebHook/MandrillInboundMessageInfo.cs
@@ -11,6 +11,8 @@ namespace Mandrill.Model
 
         public string FromEmail { get; set; }
 
+        public string FromName { get; set; }
+
         public Dictionary<string, object> Headers { get; set; } = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 
         public string Html { get; set; }
@@ -38,5 +40,7 @@ namespace Mandrill.Model
         public bool TextFlowed { get; set; }
 
         public List<List<string>> To { get; set; } = new List<List<string>>();
+
+        public List<List<string>> Cc { get; set; } = new List<List<string>>();
     }
 }

--- a/tests/SerializationTests.cs
+++ b/tests/SerializationTests.cs
@@ -378,10 +378,15 @@ namespace Tests
 
             events[0].Msg.To[0][0].Should().Be("test@inbound.example.com");
 
+            events[0].Msg.Cc[0][0].Should().Be("testCc@inbound.example.com");
+
             events[1].Msg.Attachments.Count.Should().Be(1);
             events[1].Msg.Attachments.First().Value.Content.Should().NotBeEmpty();
             events[1].Msg.Images.Count.Should().Be(1);
             events[1].Msg.Images.First().Value.Content.Length.Should().BeGreaterThan(0);
+
+            events[0].Msg.FromName.Should().Be("Example Sender");
+            events[1].Msg.FromName.Should().BeNullOrEmpty();
 
             Output.WriteLine(JArray.FromObject(events, MandrillSerializer.Instance).ToString());
 

--- a/tests/TestData.cs
+++ b/tests/TestData.cs
@@ -19,6 +19,7 @@ namespace Tests
             },
             ""email"": ""test@inbound.example.com"",
             ""from_email"": ""example.sender@mandrillapp.com"",
+            ""from_name"": ""Example Sender"",
             ""headers"": {
                 ""Content-Type"": ""multipart/alternative; boundary=\""_av-7r7zDhHxVEAo2yMWasfuFw\"""",
                 ""Date"": ""Fri, 10 May 2013 19:28:20 +0000"",
@@ -128,10 +129,16 @@ namespace Tests
             ""text"": ""This is an example inbound message.\n"",
             ""text_flowed"": false,
             ""to"": [
-                [
-                    ""test@inbound.example.com"",
-                    null
-                ]
+                        [
+                            ""test@inbound.example.com"",
+                            null
+                        ]
+            ],
+            ""cc"": [
+                        [
+                            ""testCc@inbound.example.com"",
+                            null
+                        ]
             ]
         },
         ""ts"": 1368214102
@@ -145,6 +152,7 @@ namespace Tests
             },
             ""email"": ""test@inbound.example.com"",
             ""from_email"": ""example.sender@mandrillapp.com"",
+            ""from_name"": null,
             ""headers"": {
                 ""Content-Type"": ""multipart/alternative; boundary=\""_av-7r7zDhHxVEAo2yMWasfuFw\"""",
                 ""Date"": ""Fri, 10 May 2013 19:28:20 +0000"",
@@ -272,6 +280,12 @@ namespace Tests
                     ""test@inbound.example.com"",
                     null
                 ]
+            ],
+            ""cc"": [
+                        [
+                            ""testCc@inbound.example.com"",
+                            null
+                        ]
             ]
         },
         ""ts"": 1368214102


### PR DESCRIPTION
These fields are posted in the webhook message body but are not available on the MandrillInboundMessageInfo class