### PR TITLE
fix: use 1.3 path

### DIFF
--- a/spec/mandrill-openapi.json
+++ b/spec/mandrill-openapi.json
@@ -6,8 +6,8 @@
     },
     "servers": [
         {
-            "url": "https://mandrillapp.com/api/1.4",
-            "description": "Mailchimp Transactional API v1.4"
+            "url": "https://mandrillapp.com/api/1.3",
+            "description": "Mailchimp Transactional API"
         }
     ],
     "paths": {

--- a/src/Mandrill.net/DefaultHttpClient.cs
+++ b/src/Mandrill.net/DefaultHttpClient.cs
@@ -12,7 +12,7 @@ namespace Mandrill
 
         }
         private static readonly Lazy<Version> UserAgentVersionLazy = new Lazy<Version>(() => new AssemblyName(typeof(MandrillRequest).GetTypeInfo().Assembly.FullName).Version);
-        private static readonly Uri BaseUrl = new Uri("https://mandrillapp.com/api/1.4/");
+        private static readonly Uri BaseUrl = new Uri("https://mandrillapp.com/api/1.3/");
 
         public static HttpClient CreateDefault()
         {

--- a/tests/MandrillApiTest.cs
+++ b/tests/MandrillApiTest.cs
@@ -19,7 +19,7 @@ namespace Tests
 
             using (var api = new MandrillApi("api_key", client))
             {
-                Assert.Equal("https://mandrillapp.com/api/1.4/", api.HttpClient.BaseAddress.OriginalString);
+                Assert.Equal("https://mandrillapp.com/api/1.3/", api.HttpClient.BaseAddress.OriginalString);
                 Assert.Single(api.HttpClient.DefaultRequestHeaders.Accept);
             }
         }


### PR DESCRIPTION
resolves #344 

There is a discrepancy between the basePath [here ](https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/main/spec/transactional.json) and the server url [here ](https://github.com/mailchimp/mailchimp-client-lib-codegen/blob/main/spec/transactional.openapi.json)

But there is definitely a broken behavior when rendering html merge vars when using 1.4 so we will revert to 1.3